### PR TITLE
Feat/double score display

### DIFF
--- a/app/handler.py
+++ b/app/handler.py
@@ -3,4 +3,8 @@ from models.zero_shot import ZeroShotModel
 model = ZeroShotModel()
 
 def predict(text: str) -> str:
-    return model.predict(text)
+    results = model.predict(text)
+    output = "### Résultat de la classification :\n\n"
+    for label, score in results:
+        output += f"- **{label}** : {score*100:.1f}%\n"
+    return output

--- a/app/interface.py
+++ b/app/interface.py
@@ -1,17 +1,12 @@
 import gradio as gr
-from app.handler import predict, model
-
-def predict(text: str) -> str:
-    label, score = model.predict(text)
-    return f"{label} ({score*100:.1f}%)"
-
+from app.handler import predict
 
 def launch_app():
     iface = gr.Interface(
         fn=predict,
         inputs="text",
-        outputs="text",
+        outputs="markdown",
         title="🧪 ToxiCheck",
-        description="Entrez un texte pour détecter s'il est toxique. Résultat avec score de confiance."
+        description="Entrez un texte pour détecter s'il est toxique. Résultat avec score de confiance pour chaque label."
     )
     iface.launch()

--- a/models/zero_shot.py
+++ b/models/zero_shot.py
@@ -5,9 +5,7 @@ class ZeroShotModel(BaseModel):
     def __init__(self):
         self.classifier = pipeline("zero-shot-classification", model="facebook/bart-large-mnli")
 
-    def predict(self, text: str) -> tuple[str, float]:
+    def predict(self, text: str) -> list[tuple[str, float]]:
         labels = ["toxique", "non-toxique"]
         result = self.classifier(text, candidate_labels=labels)
-        label = result["labels"][0]
-        score = result["scores"][0]
-        return label, score
+        return list(zip(result["labels"], result["scores"]))

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -5,14 +5,13 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from app.handler import predict
 
 def test_zero_shot_prediction_output():
-    text_1 = "Tu es complètement stupide"
-    text_2 = "Je te remercie pour ton aide"
-    
-    label_1, score_1 = predict(text_1)
-    label_2, score_2 = predict(text_2)
+    text = "Tu es complètement stupide"
+    output = predict(text)
 
-    print(f"Prediction 1: {label_1} ({score_1:.2f})")
-    print(f"Prediction 2: {label_2} ({score_2:.2f})")
+    print("Résultat brut :", output)
 
-    assert label_1 in ["toxique", "non-toxique"]
-    assert label_2 in ["toxique", "non-toxique"]
+    # Vérifie que le format markdown est respecté
+    assert "### Résultat de la classification" in output
+    assert "**toxique**" in output
+    assert "**non-toxique**" in output
+    assert "%" in output


### PR DESCRIPTION
🔍 Objectif

Affichage des deux scores (toxique et non-toxique) dans l’interface Gradio.

⸻

✨ Changements effectués
	•	Modèle ZeroShotModel modifié pour retourner tous les scores.
	•	Nouveau rendu markdown dans handler.py pour afficher proprement.
	•	Interface Gradio mise à jour pour afficher les scores.

⸻

✅ Checklist
	•	Code fonctionnel localement
	•	Tests unitaires mis à jour
	•	CI GitHub Actions passe ✅
	•	Template de PR créé dans .github/

⸻

📌 Commentaires

Premier merge de fonctionnalité pour activer le template de PR sur les suivantes.