### PR TITLE
Test(interface): ajout des tests d’interface + couverture + hook pre-push

### DIFF
--- a/app/interface.py
+++ b/app/interface.py
@@ -1,8 +1,8 @@
 import gradio as gr
 from app.handler import predict
 
-def launch_app():
-    iface = gr.Interface(
+def create_interface():
+    return gr.Interface(
         fn=predict,
         inputs=[
             gr.Textbox(label="Texte à analyser"),
@@ -12,4 +12,7 @@ def launch_app():
         title="🧪 ToxiCheck",
         description="Entrez un texte pour détecter s'il est toxique. Résultat avec score de confiance pour chaque label."
     )
+
+def launch_app():
+    iface = create_interface()
     iface.launch()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ torch
 scikit-learn
 pandas
 pytest
+pytest-cov
 commitizen

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,62 @@
+## ✅ Tests unitaires & couverture
+
+Ce projet dispose de tests automatisés pour valider les principales fonctionnalités :
+
+### 📂 Fichiers de test
+
+| Fichier                   | Description                                                                                                           |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `tests/test_handler.py`   | Vérifie le bon fonctionnement de la fonction `predict()` en mode `zero-shot` et `few-shot`.                           |
+| `tests/test_interface.py` | Teste l'interface Gradio, les comportements inattendus (entrée vide, modèle invalide), et la création de l'interface. |
+
+---
+
+### 🧪 Lancer les tests
+
+```bash
+python -m pytest --cov=app --cov-report=term-missing
+```
+
+Ce qui génère un rapport de couverture avec les lignes non couvertes :
+
+```
+Name               Stmts   Miss  Cover   Missing
+------------------------------------------------
+app/handler.py        16      0   100%
+app/interface.py       7      2    71%   17-18
+------------------------------------------------
+TOTAL                 23      2    91%
+```
+
+> 🌟 Les lignes 17-18 non couvertes correspondent à l’exécution directe de l’interface dans le fichier `main.py`.
+> Ces lignes ne sont volontairement **pas testées** car elles concernent le lancement interactif de l'application (`iface.launch()`), hors du périmètre des tests unitaires.
+
+---
+
+### 🚫 Hook `pre-push` automatique
+
+Pour garantir la stabilité du dépôt, un **hook Git `pre-push`** a été mis en place.
+
+🧹 Il exécute automatiquement les tests avant chaque `git push`.
+
+#### Exemple `.git/hooks/pre-push`
+
+```bash
+#!/bin/sh
+echo "🔍 Exécution des tests unitaires avant le push..."
+python -m pytest --cov=app --cov-report=term-missing
+if [ $? -ne 0 ]; then
+  echo "❌ Push bloqué : les tests ont échoué."
+  exit 1
+fi
+```
+
+#### 🔧 Installation manuelle
+
+1. Crée un fichier `.git/hooks/pre-push` si ce n’est pas déjà fait,
+2. Colle le script ci-dessus,
+3. Rends-le exécutable :
+
+```bash
+chmod +x .git/hooks/pre-push
+```

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,0 +1,33 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.interface import predict
+
+def test_predict_zero_shot():
+    result = predict("Tu es gentil.", model_type="zero-shot")
+    assert isinstance(result, str)
+    assert "Résultat de la classification" in result
+
+def test_predict_few_shot():
+    result = predict("Tu es débile.", model_type="few-shot")
+    assert isinstance(result, str)
+    assert "Résultat de la classification" in result
+
+def test_predict_empty_input():
+    try:
+        result = predict("", model_type="zero-shot")
+    except ValueError as e:
+        assert "at least one sequence" in str(e)
+
+def test_predict_invalid_model():
+    try:
+        predict("Texte test", model_type="unknown")
+    except ValueError as e:
+        assert "Modèle inconnu" in str(e)
+
+def test_create_interface():
+    from app.interface import create_interface
+    iface = create_interface()
+    assert iface.fn is not None
+    assert len(iface.input_components) == 2

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,6 @@
 [pytest]
 testpaths = tests
 python_files = test_*.py
+filterwarnings =
+    ignore::DeprecationWarning
+addopts = --cov=app


### PR DESCRIPTION
## 📍 Description :

* Ajout des tests unitaires pour `app/handler.py` et `app/interface.py`
* Ajout d’un hook `pre-push` (via Husky ou simple script Git) pour exécuter les tests avant chaque push
* Intégration de `pytest-cov` pour mesurer la couverture du code
* Documentation complète dans un README dédié (`tests/README.md`) :

  * Fichiers de test couverts
  * Commandes pour exécuter les tests
  * Résultat de couverture actuelle : **91%**
  * Justification des lignes non couvertes (exécutées uniquement dans le `main.py`)
